### PR TITLE
Update suspend() method

### DIFF
--- a/pydiscourse/client.py
+++ b/pydiscourse/client.py
@@ -130,22 +130,26 @@ class DiscourseClient(object):
         """
         return self._put('/admin/users/{0}/trust_level'.format(userid), level=level)
 
-    def suspend(self, userid, duration, reason):
+    def suspend(self, userid, suspend_until, reason, email_message=''):
         """
         Suspend a user's account
 
         Args:
             userid: the Discourse user ID
-            duration: the length of time in days for which a user's account
-                    should be suspended
-            reason: the reason for suspending the account
+            reason: the reason for suspending the account. Displayed on user profile page
+            suspend_until: the date and time the user will be able to log in again.
+            email_message: Optional text to include in email notifying user of suspension
 
+        Examples:
+            discourse_client.suspend(42, "3017-10-06 08:00", "Suspending user forever as they have left")
+            discourse_client.suspend(427, "2018-10-06 08:00", "Suspended for spamming", "You have been suspended for spamming. Please improve your behaviour when you are able to rejoin us on 2018-10-06 08:00")
         Returns:
             ????
 
         """
         return self._put('/admin/users/{0}/suspend'.format(userid),
-                         duration=duration, reason=reason)
+                         suspend_until=suspend_until, reason=reason,
+                         message=email_message)
 
     def unsuspend(self, userid):
         """


### PR DESCRIPTION
Although the docs haven't been updated, the user suspension API was changed from 'suspend for x days' to a 'suspend until x date' .
https://github.com/discourse/discourse/commit/6bce3004d905af443c81a11c4a8219947961dd77
http://docs.discourse.org/#tag/Admin%2Fpaths%2F~1admin~1users~1%7Bid%7D~1suspend%2Fput

Suspend user id 4406 "forever" (per discourse web UI)

    curl -H "X-Requested-With: XMLHttpRequest" -H "Content-Type: application/json" -X PUT -d '{"suspend_until":"3017-10-06 08:00", "reason":"some new reason", "message":""}' 'https://example/admin/users/4406/suspend?api_username=user&api_key=key'

 Note the JSON returned by the API doesn't match the query word for word - for example, 'suspended_till'

    {"suspension":{"suspended":true,"suspend_reason":"some new reason","suspended_till":"3017-10-06T08:00:00.000Z","suspended_at":"2017-10-05T22:44:35.789Z"}}

I haven't yet tested these changes but I'm flagging it up to try and remind me to review/revisit when possible or for someone else to benefit from my trouble :).